### PR TITLE
Use Empty for HealthCheck request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: client
 client:
-	protoc \
-		--proto_path=protobuf \
+	protoc --proto_path=protobuf \
 		--cpp_out=src/protobuf \
 		--grpc_out src/protobuf \
 		--plugin=protoc-gen-grpc=`which grpc_cpp_plugin` \
@@ -9,8 +8,7 @@ client:
 
  .PHONY: pyclient
  pyclient:
-	protoc \
-		--proto_path=protobuf \
+	python -m grpc_tools.protoc --proto_path=protobuf \
 		--python_out=python \
 		--grpc_python_out=python \
 		protobuf/faiss.proto

--- a/example/client/healthcheck.py
+++ b/example/client/healthcheck.py
@@ -2,6 +2,7 @@ import argparse
 import grpc
 import faiss_pb2
 import faiss_pb2_grpc
+from google.protobuf import empty_pb2
 
 
 def main(args):

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,4 @@
 gensim==3.5.0
 tqdm==4.23.4
 grpcio==1.13.0
+protobuf==3.6.0

--- a/protobuf/faiss.proto
+++ b/protobuf/faiss.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package faiss;
 
-message HealthCheckRequest {};
+import "google/protobuf/empty.proto";
 
 message HealthCheckResponse {
     string message = 1;
@@ -37,7 +37,7 @@ message SearchByIdResponse {
 };
 
 service FaissService {
-    rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse);
+    rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse);
     rpc Search(SearchRequest) returns (SearchResponse);
     rpc SearchById(SearchByIdRequest) returns (SearchByIdResponse);
 };

--- a/python/faiss_pb2.py
+++ b/python/faiss_pb2.py
@@ -13,40 +13,18 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
+from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='faiss.proto',
   package='faiss',
   syntax='proto3',
-  serialized_pb=_b('\n\x0b\x66\x61iss.proto\x12\x05\x66\x61iss\"\x14\n\x12HealthCheckRequest\"&\n\x13HealthCheckResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"\x1b\n\x06Vector\x12\x11\n\tfloat_val\x18\x05 \x03(\x02\"=\n\rSearchRequest\x12\x1d\n\x06vector\x18\x01 \x01(\x0b\x32\r.faiss.Vector\x12\r\n\x05top_k\x18\x02 \x01(\x04\"%\n\x08Neighbor\x12\n\n\x02id\x18\x01 \x01(\x04\x12\r\n\x05score\x18\x02 \x01(\x02\"4\n\x0eSearchResponse\x12\"\n\tneighbors\x18\x02 \x03(\x0b\x32\x0f.faiss.Neighbor\".\n\x11SearchByIdRequest\x12\n\n\x02id\x18\x01 \x01(\x04\x12\r\n\x05top_k\x18\x02 \x01(\x04\"L\n\x12SearchByIdResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\x04\x12\"\n\tneighbors\x18\x02 \x03(\x0b\x32\x0f.faiss.Neighbor2\xce\x01\n\x0c\x46\x61issService\x12\x44\n\x0bHealthCheck\x12\x19.faiss.HealthCheckRequest\x1a\x1a.faiss.HealthCheckResponse\x12\x35\n\x06Search\x12\x14.faiss.SearchRequest\x1a\x15.faiss.SearchResponse\x12\x41\n\nSearchById\x12\x18.faiss.SearchByIdRequest\x1a\x19.faiss.SearchByIdResponseb\x06proto3')
-)
+  serialized_pb=_b('\n\x0b\x66\x61iss.proto\x12\x05\x66\x61iss\x1a\x1bgoogle/protobuf/empty.proto\"&\n\x13HealthCheckResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"\x1b\n\x06Vector\x12\x11\n\tfloat_val\x18\x05 \x03(\x02\"=\n\rSearchRequest\x12\x1d\n\x06vector\x18\x01 \x01(\x0b\x32\r.faiss.Vector\x12\r\n\x05top_k\x18\x02 \x01(\x04\"%\n\x08Neighbor\x12\n\n\x02id\x18\x01 \x01(\x04\x12\r\n\x05score\x18\x02 \x01(\x02\"4\n\x0eSearchResponse\x12\"\n\tneighbors\x18\x02 \x03(\x0b\x32\x0f.faiss.Neighbor\".\n\x11SearchByIdRequest\x12\n\n\x02id\x18\x01 \x01(\x04\x12\r\n\x05top_k\x18\x02 \x01(\x04\"L\n\x12SearchByIdResponse\x12\x12\n\nrequest_id\x18\x01 \x01(\x04\x12\"\n\tneighbors\x18\x02 \x03(\x0b\x32\x0f.faiss.Neighbor2\xcb\x01\n\x0c\x46\x61issService\x12\x41\n\x0bHealthCheck\x12\x16.google.protobuf.Empty\x1a\x1a.faiss.HealthCheckResponse\x12\x35\n\x06Search\x12\x14.faiss.SearchRequest\x1a\x15.faiss.SearchResponse\x12\x41\n\nSearchById\x12\x18.faiss.SearchByIdRequest\x1a\x19.faiss.SearchByIdResponseb\x06proto3')
+  ,
+  dependencies=[google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
 
 
-
-
-_HEALTHCHECKREQUEST = _descriptor.Descriptor(
-  name='HealthCheckRequest',
-  full_name='faiss.HealthCheckRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=22,
-  serialized_end=42,
-)
 
 
 _HEALTHCHECKRESPONSE = _descriptor.Descriptor(
@@ -75,8 +53,8 @@ _HEALTHCHECKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=44,
-  serialized_end=82,
+  serialized_start=51,
+  serialized_end=89,
 )
 
 
@@ -106,8 +84,8 @@ _VECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=84,
-  serialized_end=111,
+  serialized_start=91,
+  serialized_end=118,
 )
 
 
@@ -144,8 +122,8 @@ _SEARCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=113,
-  serialized_end=174,
+  serialized_start=120,
+  serialized_end=181,
 )
 
 
@@ -182,8 +160,8 @@ _NEIGHBOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=176,
-  serialized_end=213,
+  serialized_start=183,
+  serialized_end=220,
 )
 
 
@@ -213,8 +191,8 @@ _SEARCHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=215,
-  serialized_end=267,
+  serialized_start=222,
+  serialized_end=274,
 )
 
 
@@ -251,8 +229,8 @@ _SEARCHBYIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=269,
-  serialized_end=315,
+  serialized_start=276,
+  serialized_end=322,
 )
 
 
@@ -289,14 +267,13 @@ _SEARCHBYIDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=317,
-  serialized_end=393,
+  serialized_start=324,
+  serialized_end=400,
 )
 
 _SEARCHREQUEST.fields_by_name['vector'].message_type = _VECTOR
 _SEARCHRESPONSE.fields_by_name['neighbors'].message_type = _NEIGHBOR
 _SEARCHBYIDRESPONSE.fields_by_name['neighbors'].message_type = _NEIGHBOR
-DESCRIPTOR.message_types_by_name['HealthCheckRequest'] = _HEALTHCHECKREQUEST
 DESCRIPTOR.message_types_by_name['HealthCheckResponse'] = _HEALTHCHECKRESPONSE
 DESCRIPTOR.message_types_by_name['Vector'] = _VECTOR
 DESCRIPTOR.message_types_by_name['SearchRequest'] = _SEARCHREQUEST
@@ -305,13 +282,6 @@ DESCRIPTOR.message_types_by_name['SearchResponse'] = _SEARCHRESPONSE
 DESCRIPTOR.message_types_by_name['SearchByIdRequest'] = _SEARCHBYIDREQUEST
 DESCRIPTOR.message_types_by_name['SearchByIdResponse'] = _SEARCHBYIDRESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
-HealthCheckRequest = _reflection.GeneratedProtocolMessageType('HealthCheckRequest', (_message.Message,), dict(
-  DESCRIPTOR = _HEALTHCHECKREQUEST,
-  __module__ = 'faiss_pb2'
-  # @@protoc_insertion_point(class_scope:faiss.HealthCheckRequest)
-  ))
-_sym_db.RegisterMessage(HealthCheckRequest)
 
 HealthCheckResponse = _reflection.GeneratedProtocolMessageType('HealthCheckResponse', (_message.Message,), dict(
   DESCRIPTOR = _HEALTHCHECKRESPONSE,
@@ -370,15 +340,15 @@ _FAISSSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=396,
-  serialized_end=602,
+  serialized_start=403,
+  serialized_end=606,
   methods=[
   _descriptor.MethodDescriptor(
     name='HealthCheck',
     full_name='faiss.FaissService.HealthCheck',
     index=0,
     containing_service=None,
-    input_type=_HEALTHCHECKREQUEST,
+    input_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
     output_type=_HEALTHCHECKRESPONSE,
     options=None,
   ),

--- a/python/faiss_pb2_grpc.py
+++ b/python/faiss_pb2_grpc.py
@@ -2,6 +2,7 @@
 import grpc
 
 import faiss_pb2 as faiss__pb2
+from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class FaissServiceStub(object):
@@ -16,7 +17,7 @@ class FaissServiceStub(object):
     """
     self.HealthCheck = channel.unary_unary(
         '/faiss.FaissService/HealthCheck',
-        request_serializer=faiss__pb2.HealthCheckRequest.SerializeToString,
+        request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
         response_deserializer=faiss__pb2.HealthCheckResponse.FromString,
         )
     self.Search = channel.unary_unary(
@@ -61,7 +62,7 @@ def add_FaissServiceServicer_to_server(servicer, server):
   rpc_method_handlers = {
       'HealthCheck': grpc.unary_unary_rpc_method_handler(
           servicer.HealthCheck,
-          request_deserializer=faiss__pb2.HealthCheckRequest.FromString,
+          request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
           response_serializer=faiss__pb2.HealthCheckResponse.SerializeToString,
       ),
       'Search': grpc.unary_unary_rpc_method_handler(

--- a/src/protobuf/faiss.grpc.pb.cc
+++ b/src/protobuf/faiss.grpc.pb.cc
@@ -33,15 +33,15 @@ FaissService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chann
   , rpcmethod_SearchById_(FaissService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::Status FaissService::Stub::HealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::faiss::HealthCheckResponse* response) {
+::grpc::Status FaissService::Stub::HealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::faiss::HealthCheckResponse* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_HealthCheck_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* FaissService::Stub::AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* FaissService::Stub::AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::faiss::HealthCheckResponse>::Create(channel_.get(), cq, rpcmethod_HealthCheck_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* FaissService::Stub::PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* FaissService::Stub::PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::faiss::HealthCheckResponse>::Create(channel_.get(), cq, rpcmethod_HealthCheck_, context, request, false);
 }
 
@@ -73,7 +73,7 @@ FaissService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       FaissService_method_names[0],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< FaissService::Service, ::faiss::HealthCheckRequest, ::faiss::HealthCheckResponse>(
+      new ::grpc::internal::RpcMethodHandler< FaissService::Service, ::google::protobuf::Empty, ::faiss::HealthCheckResponse>(
           std::mem_fn(&FaissService::Service::HealthCheck), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       FaissService_method_names[1],
@@ -90,7 +90,7 @@ FaissService::Service::Service() {
 FaissService::Service::~Service() {
 }
 
-::grpc::Status FaissService::Service::HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response) {
+::grpc::Status FaissService::Service::HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/protobuf/faiss.grpc.pb.h
+++ b/src/protobuf/faiss.grpc.pb.h
@@ -34,11 +34,11 @@ class FaissService final {
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    virtual ::grpc::Status HealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::faiss::HealthCheckResponse* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>> AsyncHealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+    virtual ::grpc::Status HealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::faiss::HealthCheckResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>> AsyncHealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>>(AsyncHealthCheckRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>> PrepareAsyncHealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>> PrepareAsyncHealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>>(PrepareAsyncHealthCheckRaw(context, request, cq));
     }
     virtual ::grpc::Status Search(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::faiss::SearchResponse* response) = 0;
@@ -56,8 +56,8 @@ class FaissService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::faiss::SearchByIdResponse>>(PrepareAsyncSearchByIdRaw(context, request, cq));
     }
   private:
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>* AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>* PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>* AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::HealthCheckResponse>* PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::SearchResponse>* AsyncSearchRaw(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::SearchResponse>* PrepareAsyncSearchRaw(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::faiss::SearchByIdResponse>* AsyncSearchByIdRaw(::grpc::ClientContext* context, const ::faiss::SearchByIdRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -66,11 +66,11 @@ class FaissService final {
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    ::grpc::Status HealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::faiss::HealthCheckResponse* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>> AsyncHealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+    ::grpc::Status HealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::faiss::HealthCheckResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>> AsyncHealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>>(AsyncHealthCheckRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>> PrepareAsyncHealthCheck(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>> PrepareAsyncHealthCheck(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>>(PrepareAsyncHealthCheckRaw(context, request, cq));
     }
     ::grpc::Status Search(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::faiss::SearchResponse* response) override;
@@ -90,8 +90,8 @@ class FaissService final {
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::faiss::HealthCheckRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* AsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::faiss::HealthCheckResponse>* PrepareAsyncHealthCheckRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::faiss::SearchResponse>* AsyncSearchRaw(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::faiss::SearchResponse>* PrepareAsyncSearchRaw(::grpc::ClientContext* context, const ::faiss::SearchRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::faiss::SearchByIdResponse>* AsyncSearchByIdRaw(::grpc::ClientContext* context, const ::faiss::SearchByIdRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -106,7 +106,7 @@ class FaissService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response);
+    virtual ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response);
     virtual ::grpc::Status Search(::grpc::ServerContext* context, const ::faiss::SearchRequest* request, ::faiss::SearchResponse* response);
     virtual ::grpc::Status SearchById(::grpc::ServerContext* context, const ::faiss::SearchByIdRequest* request, ::faiss::SearchByIdResponse* response);
   };
@@ -122,11 +122,11 @@ class FaissService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response) override {
+    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestHealthCheck(::grpc::ServerContext* context, ::faiss::HealthCheckRequest* request, ::grpc::ServerAsyncResponseWriter< ::faiss::HealthCheckResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestHealthCheck(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::faiss::HealthCheckResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -183,7 +183,7 @@ class FaissService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response) override {
+    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -234,7 +234,7 @@ class FaissService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response) override {
+    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -289,18 +289,18 @@ class FaissService final {
    public:
     WithStreamedUnaryMethod_HealthCheck() {
       ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler< ::faiss::HealthCheckRequest, ::faiss::HealthCheckResponse>(std::bind(&WithStreamedUnaryMethod_HealthCheck<BaseClass>::StreamedHealthCheck, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::google::protobuf::Empty, ::faiss::HealthCheckResponse>(std::bind(&WithStreamedUnaryMethod_HealthCheck<BaseClass>::StreamedHealthCheck, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_HealthCheck() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::faiss::HealthCheckRequest* request, ::faiss::HealthCheckResponse* response) override {
+    ::grpc::Status HealthCheck(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::faiss::HealthCheckResponse* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedHealthCheck(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::faiss::HealthCheckRequest,::faiss::HealthCheckResponse>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedHealthCheck(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::faiss::HealthCheckResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_Search : public BaseClass {

--- a/src/protobuf/faiss.pb.cc
+++ b/src/protobuf/faiss.pb.cc
@@ -24,11 +24,6 @@ extern PROTOBUF_INTERNAL_EXPORT_protobuf_faiss_2eproto ::google::protobuf::inter
 extern PROTOBUF_INTERNAL_EXPORT_protobuf_faiss_2eproto ::google::protobuf::internal::SCCInfo<0> scc_info_Vector;
 }  // namespace protobuf_faiss_2eproto
 namespace faiss {
-class HealthCheckRequestDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<HealthCheckRequest>
-      _instance;
-} _HealthCheckRequest_default_instance_;
 class HealthCheckResponseDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<HealthCheckResponse>
@@ -66,20 +61,6 @@ class SearchByIdResponseDefaultTypeInternal {
 } _SearchByIdResponse_default_instance_;
 }  // namespace faiss
 namespace protobuf_faiss_2eproto {
-static void InitDefaultsHealthCheckRequest() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::faiss::_HealthCheckRequest_default_instance_;
-    new (ptr) ::faiss::HealthCheckRequest();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::faiss::HealthCheckRequest::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_HealthCheckRequest =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsHealthCheckRequest}, {}};
-
 static void InitDefaultsHealthCheckResponse() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -182,7 +163,6 @@ static void InitDefaultsSearchByIdResponse() {
       &protobuf_faiss_2eproto::scc_info_Neighbor.base,}};
 
 void InitDefaults() {
-  ::google::protobuf::internal::InitSCC(&scc_info_HealthCheckRequest.base);
   ::google::protobuf::internal::InitSCC(&scc_info_HealthCheckResponse.base);
   ::google::protobuf::internal::InitSCC(&scc_info_Vector.base);
   ::google::protobuf::internal::InitSCC(&scc_info_SearchRequest.base);
@@ -192,14 +172,9 @@ void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_SearchByIdResponse.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[8];
+::google::protobuf::Metadata file_level_metadata[7];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::faiss::HealthCheckRequest, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::faiss::HealthCheckResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -248,18 +223,16 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::faiss::SearchByIdResponse, neighbors_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::faiss::HealthCheckRequest)},
-  { 5, -1, sizeof(::faiss::HealthCheckResponse)},
-  { 11, -1, sizeof(::faiss::Vector)},
-  { 17, -1, sizeof(::faiss::SearchRequest)},
-  { 24, -1, sizeof(::faiss::Neighbor)},
-  { 31, -1, sizeof(::faiss::SearchResponse)},
-  { 37, -1, sizeof(::faiss::SearchByIdRequest)},
-  { 44, -1, sizeof(::faiss::SearchByIdResponse)},
+  { 0, -1, sizeof(::faiss::HealthCheckResponse)},
+  { 6, -1, sizeof(::faiss::Vector)},
+  { 12, -1, sizeof(::faiss::SearchRequest)},
+  { 19, -1, sizeof(::faiss::Neighbor)},
+  { 26, -1, sizeof(::faiss::SearchResponse)},
+  { 32, -1, sizeof(::faiss::SearchByIdRequest)},
+  { 39, -1, sizeof(::faiss::SearchByIdResponse)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::faiss::_HealthCheckRequest_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::faiss::_HealthCheckResponse_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::faiss::_Vector_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::faiss::_SearchRequest_default_instance_),
@@ -284,33 +257,34 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 8);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 7);
 }
 
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\013faiss.proto\022\005faiss\"\024\n\022HealthCheckReque"
-      "st\"&\n\023HealthCheckResponse\022\017\n\007message\030\001 \001"
-      "(\t\"\033\n\006Vector\022\021\n\tfloat_val\030\005 \003(\002\"=\n\rSearc"
-      "hRequest\022\035\n\006vector\030\001 \001(\0132\r.faiss.Vector\022"
-      "\r\n\005top_k\030\002 \001(\004\"%\n\010Neighbor\022\n\n\002id\030\001 \001(\004\022\r"
-      "\n\005score\030\002 \001(\002\"4\n\016SearchResponse\022\"\n\tneigh"
-      "bors\030\002 \003(\0132\017.faiss.Neighbor\".\n\021SearchByI"
-      "dRequest\022\n\n\002id\030\001 \001(\004\022\r\n\005top_k\030\002 \001(\004\"L\n\022S"
-      "earchByIdResponse\022\022\n\nrequest_id\030\001 \001(\004\022\"\n"
-      "\tneighbors\030\002 \003(\0132\017.faiss.Neighbor2\316\001\n\014Fa"
-      "issService\022D\n\013HealthCheck\022\031.faiss.Health"
-      "CheckRequest\032\032.faiss.HealthCheckResponse"
-      "\0225\n\006Search\022\024.faiss.SearchRequest\032\025.faiss"
-      ".SearchResponse\022A\n\nSearchById\022\030.faiss.Se"
-      "archByIdRequest\032\031.faiss.SearchByIdRespon"
-      "seb\006proto3"
+      "\n\013faiss.proto\022\005faiss\032\033google/protobuf/em"
+      "pty.proto\"&\n\023HealthCheckResponse\022\017\n\007mess"
+      "age\030\001 \001(\t\"\033\n\006Vector\022\021\n\tfloat_val\030\005 \003(\002\"="
+      "\n\rSearchRequest\022\035\n\006vector\030\001 \001(\0132\r.faiss."
+      "Vector\022\r\n\005top_k\030\002 \001(\004\"%\n\010Neighbor\022\n\n\002id\030"
+      "\001 \001(\004\022\r\n\005score\030\002 \001(\002\"4\n\016SearchResponse\022\""
+      "\n\tneighbors\030\002 \003(\0132\017.faiss.Neighbor\".\n\021Se"
+      "archByIdRequest\022\n\n\002id\030\001 \001(\004\022\r\n\005top_k\030\002 \001"
+      "(\004\"L\n\022SearchByIdResponse\022\022\n\nrequest_id\030\001"
+      " \001(\004\022\"\n\tneighbors\030\002 \003(\0132\017.faiss.Neighbor"
+      "2\313\001\n\014FaissService\022A\n\013HealthCheck\022\026.googl"
+      "e.protobuf.Empty\032\032.faiss.HealthCheckResp"
+      "onse\0225\n\006Search\022\024.faiss.SearchRequest\032\025.f"
+      "aiss.SearchResponse\022A\n\nSearchById\022\030.fais"
+      "s.SearchByIdRequest\032\031.faiss.SearchByIdRe"
+      "sponseb\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 610);
+      descriptor, 614);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "faiss.proto", &protobuf_RegisterTypes);
+  ::protobuf_google_2fprotobuf_2fempty_2eproto::AddDescriptors();
 }
 
 void AddDescriptors() {
@@ -325,185 +299,6 @@ struct StaticDescriptorInitializer {
 } static_descriptor_initializer;
 }  // namespace protobuf_faiss_2eproto
 namespace faiss {
-
-// ===================================================================
-
-void HealthCheckRequest::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-HealthCheckRequest::HealthCheckRequest()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_faiss_2eproto::scc_info_HealthCheckRequest.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:faiss.HealthCheckRequest)
-}
-HealthCheckRequest::HealthCheckRequest(const HealthCheckRequest& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:faiss.HealthCheckRequest)
-}
-
-void HealthCheckRequest::SharedCtor() {
-}
-
-HealthCheckRequest::~HealthCheckRequest() {
-  // @@protoc_insertion_point(destructor:faiss.HealthCheckRequest)
-  SharedDtor();
-}
-
-void HealthCheckRequest::SharedDtor() {
-}
-
-void HealthCheckRequest::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* HealthCheckRequest::descriptor() {
-  ::protobuf_faiss_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_faiss_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const HealthCheckRequest& HealthCheckRequest::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_faiss_2eproto::scc_info_HealthCheckRequest.base);
-  return *internal_default_instance();
-}
-
-
-void HealthCheckRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:faiss.HealthCheckRequest)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _internal_metadata_.Clear();
-}
-
-bool HealthCheckRequest::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:faiss.HealthCheckRequest)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
-    }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
-  }
-success:
-  // @@protoc_insertion_point(parse_success:faiss.HealthCheckRequest)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:faiss.HealthCheckRequest)
-  return false;
-#undef DO_
-}
-
-void HealthCheckRequest::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:faiss.HealthCheckRequest)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:faiss.HealthCheckRequest)
-}
-
-::google::protobuf::uint8* HealthCheckRequest::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:faiss.HealthCheckRequest)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:faiss.HealthCheckRequest)
-  return target;
-}
-
-size_t HealthCheckRequest::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:faiss.HealthCheckRequest)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void HealthCheckRequest::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:faiss.HealthCheckRequest)
-  GOOGLE_DCHECK_NE(&from, this);
-  const HealthCheckRequest* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const HealthCheckRequest>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:faiss.HealthCheckRequest)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:faiss.HealthCheckRequest)
-    MergeFrom(*source);
-  }
-}
-
-void HealthCheckRequest::MergeFrom(const HealthCheckRequest& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:faiss.HealthCheckRequest)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-}
-
-void HealthCheckRequest::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:faiss.HealthCheckRequest)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void HealthCheckRequest::CopyFrom(const HealthCheckRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:faiss.HealthCheckRequest)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool HealthCheckRequest::IsInitialized() const {
-  return true;
-}
-
-void HealthCheckRequest::Swap(HealthCheckRequest* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void HealthCheckRequest::InternalSwap(HealthCheckRequest* other) {
-  using std::swap;
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata HealthCheckRequest::GetMetadata() const {
-  protobuf_faiss_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_faiss_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
 
 // ===================================================================
 
@@ -2296,9 +2091,6 @@ void SearchByIdResponse::InternalSwap(SearchByIdResponse* other) {
 }  // namespace faiss
 namespace google {
 namespace protobuf {
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::faiss::HealthCheckRequest* Arena::CreateMaybeMessage< ::faiss::HealthCheckRequest >(Arena* arena) {
-  return Arena::CreateInternal< ::faiss::HealthCheckRequest >(arena);
-}
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::faiss::HealthCheckResponse* Arena::CreateMaybeMessage< ::faiss::HealthCheckResponse >(Arena* arena) {
   return Arena::CreateInternal< ::faiss::HealthCheckResponse >(arena);
 }

--- a/src/protobuf/faiss.pb.h
+++ b/src/protobuf/faiss.pb.h
@@ -30,6 +30,7 @@
 #include <google/protobuf/repeated_field.h>  // IWYU pragma: export
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
 #include <google/protobuf/unknown_field_set.h>
+#include <google/protobuf/empty.pb.h>
 // @@protoc_insertion_point(includes)
 #define PROTOBUF_INTERNAL_EXPORT_protobuf_faiss_2eproto 
 
@@ -38,7 +39,7 @@ namespace protobuf_faiss_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[8];
+  static const ::google::protobuf::internal::ParseTable schema[7];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -46,9 +47,6 @@ struct TableStruct {
 void AddDescriptors();
 }  // namespace protobuf_faiss_2eproto
 namespace faiss {
-class HealthCheckRequest;
-class HealthCheckRequestDefaultTypeInternal;
-extern HealthCheckRequestDefaultTypeInternal _HealthCheckRequest_default_instance_;
 class HealthCheckResponse;
 class HealthCheckResponseDefaultTypeInternal;
 extern HealthCheckResponseDefaultTypeInternal _HealthCheckResponse_default_instance_;
@@ -73,7 +71,6 @@ extern VectorDefaultTypeInternal _Vector_default_instance_;
 }  // namespace faiss
 namespace google {
 namespace protobuf {
-template<> ::faiss::HealthCheckRequest* Arena::CreateMaybeMessage<::faiss::HealthCheckRequest>(Arena*);
 template<> ::faiss::HealthCheckResponse* Arena::CreateMaybeMessage<::faiss::HealthCheckResponse>(Arena*);
 template<> ::faiss::Neighbor* Arena::CreateMaybeMessage<::faiss::Neighbor>(Arena*);
 template<> ::faiss::SearchByIdRequest* Arena::CreateMaybeMessage<::faiss::SearchByIdRequest>(Arena*);
@@ -86,102 +83,6 @@ template<> ::faiss::Vector* Arena::CreateMaybeMessage<::faiss::Vector>(Arena*);
 namespace faiss {
 
 // ===================================================================
-
-class HealthCheckRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:faiss.HealthCheckRequest) */ {
- public:
-  HealthCheckRequest();
-  virtual ~HealthCheckRequest();
-
-  HealthCheckRequest(const HealthCheckRequest& from);
-
-  inline HealthCheckRequest& operator=(const HealthCheckRequest& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  HealthCheckRequest(HealthCheckRequest&& from) noexcept
-    : HealthCheckRequest() {
-    *this = ::std::move(from);
-  }
-
-  inline HealthCheckRequest& operator=(HealthCheckRequest&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const HealthCheckRequest& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const HealthCheckRequest* internal_default_instance() {
-    return reinterpret_cast<const HealthCheckRequest*>(
-               &_HealthCheckRequest_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    0;
-
-  void Swap(HealthCheckRequest* other);
-  friend void swap(HealthCheckRequest& a, HealthCheckRequest& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline HealthCheckRequest* New() const final {
-    return CreateMaybeMessage<HealthCheckRequest>(NULL);
-  }
-
-  HealthCheckRequest* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<HealthCheckRequest>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const HealthCheckRequest& from);
-  void MergeFrom(const HealthCheckRequest& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(HealthCheckRequest* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // @@protoc_insertion_point(class_scope:faiss.HealthCheckRequest)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_faiss_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
 
 class HealthCheckResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:faiss.HealthCheckResponse) */ {
  public:
@@ -218,7 +119,7 @@ class HealthCheckResponse : public ::google::protobuf::Message /* @@protoc_inser
                &_HealthCheckResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    0;
 
   void Swap(HealthCheckResponse* other);
   friend void swap(HealthCheckResponse& a, HealthCheckResponse& b) {
@@ -329,7 +230,7 @@ class Vector : public ::google::protobuf::Message /* @@protoc_insertion_point(cl
                &_Vector_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    1;
 
   void Swap(Vector* other);
   friend void swap(Vector& a, Vector& b) {
@@ -439,7 +340,7 @@ class SearchRequest : public ::google::protobuf::Message /* @@protoc_insertion_p
                &_SearchRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    2;
 
   void Swap(SearchRequest* other);
   friend void swap(SearchRequest& a, SearchRequest& b) {
@@ -555,7 +456,7 @@ class Neighbor : public ::google::protobuf::Message /* @@protoc_insertion_point(
                &_Neighbor_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    3;
 
   void Swap(Neighbor* other);
   friend void swap(Neighbor& a, Neighbor& b) {
@@ -665,7 +566,7 @@ class SearchResponse : public ::google::protobuf::Message /* @@protoc_insertion_
                &_SearchResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    4;
 
   void Swap(SearchResponse* other);
   friend void swap(SearchResponse& a, SearchResponse& b) {
@@ -774,7 +675,7 @@ class SearchByIdRequest : public ::google::protobuf::Message /* @@protoc_inserti
                &_SearchByIdRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    5;
 
   void Swap(SearchByIdRequest* other);
   friend void swap(SearchByIdRequest& a, SearchByIdRequest& b) {
@@ -884,7 +785,7 @@ class SearchByIdResponse : public ::google::protobuf::Message /* @@protoc_insert
                &_SearchByIdResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    6;
 
   void Swap(SearchByIdResponse* other);
   friend void swap(SearchByIdResponse& a, SearchByIdResponse& b) {
@@ -972,10 +873,6 @@ class SearchByIdResponse : public ::google::protobuf::Message /* @@protoc_insert
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
-// HealthCheckRequest
-
-// -------------------------------------------------------------------
-
 // HealthCheckResponse
 
 // string message = 1;
@@ -1286,8 +1183,6 @@ SearchByIdResponse::neighbors() const {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
-// -------------------------------------------------------------------
-
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/service_impl.cpp
+++ b/src/service_impl.cpp
@@ -17,9 +17,9 @@ FaissServiceImpl::FaissServiceImpl(const std::shared_ptr<logger>& logger,
   }
 }
 
-grpc::Status FaissServiceImpl::HealthCheck(grpc::ServerContext* context,
-                                           const HealthCheckRequest* request,
-                                           HealthCheckResponse* response) {
+grpc::Status FaissServiceImpl::HealthCheck(
+    grpc::ServerContext* context, const ::google::protobuf::Empty* request,
+    HealthCheckResponse* response) {
   logger_->info("HealthCheck");
   response->set_message("OK");
   return grpc::Status::OK;

--- a/src/service_impl.h
+++ b/src/service_impl.h
@@ -9,7 +9,6 @@
 #include "protobuf/faiss.grpc.pb.h"
 
 using faiss::FaissService;
-using faiss::HealthCheckRequest;
 using faiss::HealthCheckResponse;
 using faiss::SearchByIdRequest;
 using faiss::SearchByIdResponse;
@@ -24,7 +23,7 @@ class FaissServiceImpl final : public FaissService::Service {
                    const uint& default_top_k, const char* file_path);
 
   grpc::Status HealthCheck(grpc::ServerContext* context,
-                           const HealthCheckRequest* request,
+                           const ::google::protobuf::Empty* request,
                            HealthCheckResponse* response) override;
 
   grpc::Status Search(grpc::ServerContext* context,


### PR DESCRIPTION
### Overview

- Fix #1.
  - Use `Empty` for `HealthCheck` request.
